### PR TITLE
feat: rename the project and dependencies for the equinix-labs org

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,14 +3,14 @@
 Experimental Github Action for managing [Equinix Metal](https://metal.equinix.com) Projects.
 
 > :bulb: See also:
-> * [equinix-metal-project](https://github.com/displague/metal-project-action) action
-> * [equinix-metal-examples](https://github.com/displague/metal-actions-example) examples
+> * [equinix-metal-project](https://github.com/equinix-labs/metal-project-action) action
+> * [equinix-metal-examples](https://github.com/equinix-labs/metal-actions-example) examples
 
 Given a Equinix Metal User API Token and a Project ID, the project will be deleted with all resources in that project.
 
-Create a project with the [Equinix Metal Project Action](https://github.com/displague/metal-project-action).
+Create a project with the [Equinix Metal Project Action](https://github.com/equinix-labs/metal-project-action).
 
-See the [Equinix Metal Actions Example](https://github.com/displague/metal-actions-example) for usage examples.
+See the [Equinix Metal Actions Example](https://github.com/equinix-labs/metal-actions-example) for usage examples.
 
 ## Input
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/displague/metal-sweeper-action
+module github.com/equinix-labs/metal-sweeper-action
 
 go 1.14
 


### PR DESCRIPTION
Moves the project docs and dependencies to equinix-labs from displague, along with
* https://github.com/equinix-labs/metal-actions-example/pull/3
* https://github.com/equinix-labs/metal-project-action/pull/11